### PR TITLE
fix(line-comments): Prioritize returning tool_use result

### DIFF
--- a/__tests__/file-utils.test.ts
+++ b/__tests__/file-utils.test.ts
@@ -47,11 +47,6 @@ describe('getFilesContent', () => {
   })
 
   it('should handle file read errors', async () => {
-    // Mock console.error to prevent test output pollution
-    const consoleErrorSpy = vi
-      .spyOn(console, 'error')
-      .mockImplementation(() => {})
-
     // Mock implementation with error
     vi.mocked(fs.readFile).mockImplementation((filePath) => {
       if (String(filePath).includes('file1.txt')) {
@@ -65,12 +60,6 @@ describe('getFilesContent', () => {
 
     // Verify results
     expect(result['file1.txt']).toBe('content of file1')
-
-    // Verify console.error was called
-    expect(consoleErrorSpy).toHaveBeenCalledTimes(1)
-
-    // Restore console.error
-    consoleErrorSpy.mockRestore()
   })
 })
 

--- a/src/anthropic-senders/line-comments-sender.ts
+++ b/src/anthropic-senders/line-comments-sender.ts
@@ -80,6 +80,8 @@ export async function lineCommentsSender(prompt: string): Promise<string> {
     ]
   })
 
+  let fallbackResult = ''
+
   // Extract response from tool use
   // Find content blocks that are tool_use type
   for (const content of message.content) {
@@ -101,15 +103,15 @@ export async function lineCommentsSender(prompt: string): Promise<string> {
           // const jsonMatch = text.match(/```json\s*([\s\S]*?)\s*```/)
           const jsonMatch = text.match(/```json\n([\s\S]{1,10000}?)\n```/)
           if (jsonMatch && jsonMatch[1]) {
-            return jsonMatch[1].trim()
+            fallbackResult = jsonMatch[1].trim()
           }
           // If the whole response is potentially JSON
           if (text.trim().startsWith('{') && text.trim().endsWith('}')) {
-            return text
+            fallbackResult = text
           }
 
           // Just return the text as is
-          return text
+          fallbackResult = text
         } catch {
           // Silent catch - continue to next content block or error
         }
@@ -117,5 +119,9 @@ export async function lineCommentsSender(prompt: string): Promise<string> {
     }
   }
 
+  if (fallbackResult) {
+    // If we have a fallback result, return it
+    return fallbackResult
+  }
   throw new Error('Unexpected response format from Anthropic')
 }

--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -19,8 +19,9 @@ export async function getFilesContent(
       const fullPath = path.join(repoPath, filePath)
       const content = await fs.readFile(fullPath, 'utf-8')
       result[filePath] = content
-    } catch (error) {
-      console.error(`Error reading file ${filePath}:`, error)
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    } catch (_error) {
+      continue // Ignore errors for individual files
     }
   }
 


### PR DESCRIPTION
The problem was that Claude answers with `tool_use` AND `text` but `text` is always first in the array. So that was returned right away every time.