### PR TITLE
fix: correct fallback logic in lineCommentsSender

### DIFF
--- a/__tests__/anthropic-senders/line-comments-sender.test.ts
+++ b/__tests__/anthropic-senders/line-comments-sender.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { lineCommentsSender } from '../../src/anthropic-senders/line-comments-sender.ts'
+
+// Mock the Anthropic SDK
+vi.mock('@anthropic-ai/sdk', () => {
+  return {
+    default: vi.fn().mockImplementation(() => ({
+      messages: {
+        create: vi.fn()
+      }
+    }))
+  }
+})
+
+describe('lineCommentsSender', () => {
+  let mockAnthropic: {
+    messages: {
+      create: ReturnType<typeof vi.fn>
+    }
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+
+    // Get the mocked Anthropic constructor
+    const AnthropicConstructor = (await import('@anthropic-ai/sdk'))
+      .default as unknown as ReturnType<typeof vi.fn>
+    mockAnthropic = {
+      messages: {
+        create: vi.fn()
+      }
+    }
+    AnthropicConstructor.mockReturnValue(mockAnthropic)
+
+    // Set up environment variable
+    process.env.ANTHROPIC_API_KEY = 'test-api-key'
+  })
+
+  it('should handle successful tool use response', async () => {
+    const expectedResponse = {
+      summary: 'Test summary',
+      comments: [
+        {
+          path: 'test.ts',
+          line: 10,
+          body: 'Test comment'
+        }
+      ]
+    }
+
+    mockAnthropic.messages.create.mockResolvedValue({
+      content: [
+        {
+          type: 'tool_use',
+          name: 'provide_code_review',
+          input: expectedResponse
+        }
+      ]
+    })
+
+    const result = await lineCommentsSender('test prompt')
+    expect(result).toBe(JSON.stringify(expectedResponse))
+  })
+
+  it('should handle fallback with JSON in code block', async () => {
+    const expectedJson = {
+      summary: 'Fallback summary',
+      comments: [
+        {
+          path: 'fallback.ts',
+          line: 20,
+          body: 'Fallback comment'
+        }
+      ]
+    }
+
+    const textResponse = `Here's the analysis:
+
+\`\`\`json
+${JSON.stringify(expectedJson, null, 2)}
+\`\`\`
+
+This is the code review result.`
+
+    mockAnthropic.messages.create.mockResolvedValue({
+      content: [
+        {
+          type: 'text',
+          text: textResponse
+        }
+      ]
+    })
+
+    const result = await lineCommentsSender('test prompt')
+    expect(result).toBe(JSON.stringify(expectedJson, null, 2))
+  })
+
+  it('should handle fallback with plain JSON response', async () => {
+    const expectedJson = {
+      summary: 'Plain JSON summary',
+      comments: [
+        {
+          path: 'plain.ts',
+          line: 30,
+          body: 'Plain JSON comment'
+        }
+      ]
+    }
+
+    const jsonResponse = JSON.stringify(expectedJson)
+
+    mockAnthropic.messages.create.mockResolvedValue({
+      content: [
+        {
+          type: 'text',
+          text: jsonResponse
+        }
+      ]
+    })
+
+    const result = await lineCommentsSender('test prompt')
+    expect(result).toBe(jsonResponse)
+  })
+
+  it('should handle fallback with mixed content (JSON takes priority)', async () => {
+    const expectedJson = {
+      summary: 'Priority test',
+      comments: [
+        {
+          path: 'priority.ts',
+          line: 40,
+          body: 'Priority comment'
+        }
+      ]
+    }
+
+    const textWithJson = `Some text before
+
+\`\`\`json
+${JSON.stringify(expectedJson)}
+\`\`\`
+
+Some text after that should be ignored`
+
+    mockAnthropic.messages.create.mockResolvedValue({
+      content: [
+        {
+          type: 'text',
+          text: textWithJson
+        }
+      ]
+    })
+
+    const result = await lineCommentsSender('test prompt')
+    expect(result).toBe(JSON.stringify(expectedJson))
+  })
+
+  it('should fall back to plain text only when no JSON is found', async () => {
+    const plainTextResponse = 'This is just plain text without any JSON'
+
+    mockAnthropic.messages.create.mockResolvedValue({
+      content: [
+        {
+          type: 'text',
+          text: plainTextResponse
+        }
+      ]
+    })
+
+    const result = await lineCommentsSender('test prompt')
+    expect(result).toBe(plainTextResponse)
+  })
+
+  it('should throw error for unexpected tool name', async () => {
+    mockAnthropic.messages.create.mockResolvedValue({
+      content: [
+        {
+          type: 'tool_use',
+          name: 'unexpected_tool',
+          input: { some: 'data' }
+        }
+      ]
+    })
+
+    await expect(lineCommentsSender('test prompt')).rejects.toThrow(
+      'Unexpected tool name: unexpected_tool'
+    )
+  })
+
+  it('should throw error when no content is found', async () => {
+    mockAnthropic.messages.create.mockResolvedValue({
+      content: []
+    })
+
+    await expect(lineCommentsSender('test prompt')).rejects.toThrow(
+      'Unexpected response format from Anthropic - no content found'
+    )
+  })
+})

--- a/src/anthropic-senders/line-comments-sender.ts
+++ b/src/anthropic-senders/line-comments-sender.ts
@@ -88,6 +88,7 @@ export async function lineCommentsSender(prompt: string): Promise<string> {
   })
 
   let fallbackResult = ''
+  let hasJsonFallback = false
 
   // Extract response from tool use
   // Find content blocks that are tool_use type
@@ -97,38 +98,58 @@ export async function lineCommentsSender(prompt: string): Promise<string> {
         // Return the structured response as a JSON string
         return JSON.stringify(content.input as CodeReviewResponse)
       } else {
-        console.log('Input:', content.input)
-        console.log('Tool name:', content.name)
-        throw new Error('Tool name or input incorect')
+        console.error('Unexpected tool use response:', {
+          name: content.name,
+          input: content.input
+        })
+        throw new Error(`Unexpected tool name: ${content.name}`)
       }
-    } else {
+    } else if (content.type === 'text') {
       // Fallback if tool use failed or returned unexpected format
-      if (content.type === 'text') {
-        // Try to parse any JSON that might be in the response
-        try {
-          const text = content.text
-          // const jsonMatch = text.match(/```json\s*([\s\S]*?)\s*```/)
-          const jsonMatch = text.match(/```json\n([\s\S]{1,10000}?)\n```/)
-          if (jsonMatch && jsonMatch[1]) {
-            fallbackResult = jsonMatch[1].trim()
-          }
-          // If the whole response is potentially JSON
-          if (text.trim().startsWith('{') && text.trim().endsWith('}')) {
-            fallbackResult = text
-          }
+      console.warn(
+        'Tool use failed, attempting fallback parsing from text response'
+      )
 
-          // Just return the text as is
-          fallbackResult = text
-        } catch {
-          // Silent catch - continue to next content block or error
+      try {
+        const text = content.text
+
+        // Try to extract JSON from code blocks first
+        const jsonMatch = text.match(/```json\n([\s\S]{1,10000}?)\n```/)
+        if (jsonMatch && jsonMatch[1]) {
+          console.log('Found JSON in code block, using as fallback')
+          fallbackResult = jsonMatch[1].trim()
+          hasJsonFallback = true
+          continue // Don't overwrite with plain text
         }
+
+        // If the whole response looks like JSON
+        const trimmedText = text.trim()
+        if (trimmedText.startsWith('{') && trimmedText.endsWith('}')) {
+          console.log('Response appears to be JSON, using as fallback')
+          fallbackResult = trimmedText
+          hasJsonFallback = true
+          continue // Don't overwrite with plain text
+        }
+
+        // Only use plain text as fallback if we haven't found JSON
+        if (!hasJsonFallback) {
+          console.warn('No JSON found, using plain text as fallback')
+          fallbackResult = text
+        }
+      } catch (error) {
+        console.error('Error processing fallback text:', error)
+        // Continue to next content block
       }
     }
   }
 
   if (fallbackResult) {
     // If we have a fallback result, return it
+    console.log('Returning fallback result, hasJsonFallback:', hasJsonFallback)
     return fallbackResult
   }
-  throw new Error('Unexpected response format from Anthropic')
+
+  throw new Error(
+    'Unexpected response format from Anthropic - no content found'
+  )
 }


### PR DESCRIPTION
- Fix critical bug where fallback logic always overwrote JSON with plain text
- Add hasJsonFallback flag to properly prioritize JSON extraction
- Improve error logging with more detailed information for debugging
- Add comprehensive tests covering all fallback scenarios
- Maintain backward compatibility with existing functionality

This fixes the issue where Claude's tool use failures resulted in raw JSON being posted as comments instead of parsed line-specific comments.