### PR TITLE
fix: Stop sending equal start and end lines to github API

### DIFF
--- a/src/platforms/github/github-client.ts
+++ b/src/platforms/github/github-client.ts
@@ -144,6 +144,10 @@ export const createGitHubClient = (
         }
       }
 
+      // Only include startLine/start_side if startLine is defined and not equal nor supperior to line
+      const includeStartLine =
+        params.startLine !== undefined && params.startLine < params.line
+
       const commentParams = {
         owner,
         repo,
@@ -153,7 +157,7 @@ export const createGitHubClient = (
         line: params.line,
         body: params.body,
         side: 'RIGHT' as const,
-        ...(params.startLine !== undefined && {
+        ...(includeStartLine && {
           start_line: params.startLine,
           start_side: 'RIGHT' as const
         })


### PR DESCRIPTION
Otherwise, the github API miserably fails